### PR TITLE
env#neovim: Add `splitjoin.vim`

### DIFF
--- a/.config/nvim/config/plugin-mappings.vim
+++ b/.config/nvim/config/plugin-mappings.vim
@@ -157,6 +157,13 @@ if dein#tap('vim-peekaboo')
 endif
 " }}}
 
+" ======== SplitJoin ======== {{{
+if dein#tap('splitjoin.vim')
+  nmap gS <Plug>SplitjoinSplit
+  nmap gJ <Plug>SplitjoinJoin
+endif
+" }}}
+
 " ======== Surround ======== {{{
 if dein#tap('vim-surround')
   nmap cs  <Plug>Csurround

--- a/.config/nvim/plugins.toml
+++ b/.config/nvim/plugins.toml
@@ -168,6 +168,16 @@ hook_add = '''
   let g:peekaboo_delay = 250
 '''
 
+# SplitJoin
+# https://github.com/AndrewRadev/splitjoin.vim
+[[plugins]]
+repo = 'AndrewRadev/splitjoin.vim'
+on_map = '<Plug>Splitjoin'
+hook_add = '''
+  let g:splitjoin_join_mapping = 0
+  let g:splitjoin_split_mapping = 0
+'''
+
 # Surround
 # https://github.com/tpope/vim-surround
 [[plugins]]

--- a/doc/nvim.md
+++ b/doc/nvim.md
@@ -37,6 +37,7 @@ NeoVim
 - [MultipleCursors](#multiplecursors)
 - [NERDTree](#nerdtree)
 - [Peekaboo](#peekaboo)
+- [SplitJoin](#splitjoin)
 - [Surround](#surround)
 - [UndoTree](#undotree)
 - [FileType: Markdown](#filetype-markdown)
@@ -127,6 +128,7 @@ Name                                             | Description
 [:memo:][m-gitgutter]    | [airblade/vim-gitgutter][gitgutter]          | :octocat: Show git diffs and preview changes
 [:memo:][m-multicursors] | [terrtma/vim-multiple-cursors][multicursors] | :dart: Multiple selections
 [:memo:][m-peekaboo]     | [junegunn/vim-peekaboo][peekaboo]            | :eyes: Peeking register
+[:memo:][m-splitjoin]    | [AndrewRadev/splitjoin.vim][splitjoin]       | :hocho: Transform code between multiline and single-line
 [:memo:][m-surround]     | [tpope/vim-surround][surround]               | :coffee: Quoting pairs simple
 [:memo:][m-undotree]     | [mbbill/undotree][undotree]                  | :leftwards_arrow_with_hook: Undo history visualizer
 &nbsp;                   | [ntpeters/vim-better-whitespace][whitespace] | :coffee: Highlight trailing whitespaces and remove them on save
@@ -356,6 +358,12 @@ Keystroke                                        | Action
 |     |     | v   | <kbd>"</kbd>  | Peek register and do
 |     | v   |     | <kbd>⌃r</kbd> | Peek register and paste selected
 
+### SplitJoin
+| N   | Keystroke                | Action
+| :-: | ---------                | ------
+| v   | <kbd>g</kbd><kbd>S</kbd> | Split oneline into multiple lines
+| v   | <kbd>g</kbd><kbd>J</kbd> | Join multiple lines into oneline
+
 ### Surround
 | N   | V   | Keystroke                            | Action
 | :-: | :-: | ---------                            | ------
@@ -457,6 +465,7 @@ rm -rf ~/.cache/nvim
 [repeat]: https://github.com/tpope/vim-repeat
 [solarized8]: https://github.com/lifepillar/vim-solarized8
 [solarized]: https://github.com/altercation/vim-colors-solarized
+[splitjoin]: https://github.com/AndrewRadev/splitjoin.vim
 [surround]: https://github.com/tpope/vim-surround
 [undotree]: https://github.com/mbbill/undotree
 [whitespace]: https://github.com/ntpeters/vim-better-whitespace
@@ -474,5 +483,6 @@ rm -rf ~/.cache/nvim
 [m-multicursors]: #multiplecursors
 [m-nerdtree]: #nerdtree
 [m-peekaboo]: #peekaboo
+[m-splitjoin]: #splitjoin
 [m-surround]: #surround
 [m-undotree]: #undotree


### PR DESCRIPTION
### Changes
- Add new plugin: [AndrewRadev/splitjoin.vim](https://github.com/AndrewRadev/splitjoin.vim)
- Update [mappings](https://github.com/shirohana/environment/wiki/NeoVim-%E2%80%94-Plugin-Key-Mappings#splitjoin)

### Update Wiki
- [NeoVim](https://github.com/shirohana/environment/wiki/NeoVim/_compare/0399c3de797c0623aec9cec21147a6b0bdbcb121...20345097da9c710c79ea72983e580d777841057e)
- [NeoVim — Plugins](https://github.com/shirohana/environment/wiki/NeoVim-%E2%80%94-Plugins/_compare/836ef5fec1af134a429266bc050edfc16ac5994f...fbc9965e030d207b8dd08e4adc5855829b084702)
- [NeoVim — Plugin Key Mappings](https://github.com/shirohana/environment/wiki/NeoVim-%E2%80%94-Plugin-Key-Mappings/_compare/8300939d5bd3eefc65baf9cc681f71d188c5e842...894eb2898882166b6ec963a1bc9a5c44cf70e3cb)